### PR TITLE
Polish CFR full screen reading on larger screens

### DIFF
--- a/cfr-fullscreen-polish-v14.js
+++ b/cfr-fullscreen-polish-v14.js
@@ -1,0 +1,67 @@
+(function () {
+  const STYLE_ID = 'skyfireCfrFullScreenPolishV14';
+
+  function addStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+      @media (min-width: 760px) {
+        .skyfire-full-screen-shell {
+          width: min(calc(100% - 48px), 1320px) !important;
+          box-sizing: border-box;
+        }
+
+        .skyfire-full-screen-overlay {
+          background: #f7f9fb !important;
+        }
+
+        .skyfire-full-screen-card {
+          width: 100%;
+          box-sizing: border-box;
+        }
+      }
+
+      @media (min-width: 1280px) {
+        .skyfire-full-screen-shell {
+          width: min(calc(100% - 64px), 1400px) !important;
+        }
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function normalizeFullScreenMarkup(root) {
+    if (!root || typeof window.highlightText !== 'function') return;
+
+    root.querySelectorAll('.skyfire-full-screen-text p').forEach(function (paragraph) {
+      if (paragraph.dataset.skyfireMarkupNormalized === 'true') return;
+      const raw = paragraph.textContent || '';
+      if (/<\/?[a-z][^>]*>/i.test(raw)) {
+        paragraph.innerHTML = window.highlightText(raw, '');
+      }
+      paragraph.dataset.skyfireMarkupNormalized = 'true';
+    });
+  }
+
+  function inspectNode(node) {
+    if (!(node instanceof Element)) return;
+    if (node.matches('.skyfire-full-screen-overlay')) normalizeFullScreenMarkup(node);
+    const overlay = node.querySelector('.skyfire-full-screen-overlay');
+    if (overlay) normalizeFullScreenMarkup(overlay);
+  }
+
+  addStyles();
+
+  const existing = document.querySelector('.skyfire-full-screen-overlay');
+  if (existing) normalizeFullScreenMarkup(existing);
+
+  const observer = new MutationObserver(function (mutations) {
+    mutations.forEach(function (mutation) {
+      mutation.addedNodes.forEach(inspectNode);
+    });
+  });
+
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+})();

--- a/nested-tree.js
+++ b/nested-tree.js
@@ -2,7 +2,7 @@
 // The PPM reader is now rendered directly inside the MSHA Guidance section by ppm-guidance.js.
 // This file remains because older cached SkyFire shells still request it, and it also loads
 // v0.14 rule-specific guidance, reviewed Technical Guidance additions, stretch PPM content,
-// and source-fidelity corrections.
+// source-fidelity corrections, and CFR full-screen reading polish.
 (function () {
   window.SkyFireLegacyNestedTreeRetired = true;
 
@@ -20,4 +20,5 @@
   loadOnce('script[data-tg-reader-v14="true"]', './tg-reader-v14.js?v=v0.14-tg-reader-2', 'tgReaderV14');
   loadOnce('script[data-ppm-14109-stretch="true"]', './ppm-14109-stretch.js?v=v0.14-ppm-14109-1', 'ppm14109Stretch');
   loadOnce('script[data-ppm-source-fidelity-v14="true"]', './ppm-source-fidelity-v14.js?v=v0.14-ppm-fidelity-1', 'ppmSourceFidelityV14');
+  loadOnce('script[data-cfr-fullscreen-polish-v14="true"]', './cfr-fullscreen-polish-v14.js?v=v0.14-cfr-fullscreen-1', 'cfrFullscreenPolishV14');
 })();


### PR DESCRIPTION
Refines v0.14 CFR Full Screen View based on laptop QA. The focused reader now uses substantially more horizontal space on larger displays without increasing type size, reducing unnecessary vertical scrolling while keeping a readable centered layout. Also normalizes regulatory inline markup in Full Screen View so source formatting such as italics is rendered instead of displaying literal tags.