### PR TITLE
Clarify bookmark folder onboarding (#29)

### DIFF
--- a/bookmark-onboarding-v15.js
+++ b/bookmark-onboarding-v15.js
@@ -1,0 +1,58 @@
+(function () {
+  const STYLE_ID = 'skyfireBookmarkOnboardingV15Styles';
+  const OLD_MESSAGE = 'Create a folder to save bookmarks.';
+  const NEW_MESSAGE = 'Create a bookmark folder in the Bookmarks panel first. Then you can save this section to it.';
+
+  function addStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+      .bookmark-controls .skyfire-bookmark-folder-guidance {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        margin: 2px 0 8px;
+        padding: 10px 12px;
+        border-left: 4px solid var(--sf-regulation, #0b84ff);
+        border-radius: 8px;
+        background: #f5f8ff;
+        line-height: 1.4;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function updateGuidance(root) {
+    if (!root || typeof root.querySelectorAll !== 'function') return;
+
+    root.querySelectorAll('.bookmark-controls .inline-note').forEach(function (note) {
+      if ((note.textContent || '').trim() !== OLD_MESSAGE) return;
+      note.textContent = NEW_MESSAGE;
+      note.classList.add('skyfire-bookmark-folder-guidance');
+      note.setAttribute('role', 'note');
+    });
+  }
+
+  function inspectNode(node) {
+    if (!(node instanceof Element)) return;
+
+    if (node.matches('.bookmark-controls, .bookmark-controls .inline-note')) {
+      updateGuidance(node.matches('.bookmark-controls') ? node : node.parentElement);
+    }
+
+    updateGuidance(node);
+  }
+
+  addStyles();
+  updateGuidance(document);
+
+  const observer = new MutationObserver(function (mutations) {
+    mutations.forEach(function (mutation) {
+      mutation.addedNodes.forEach(inspectNode);
+    });
+  });
+
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+})();

--- a/bookmark-onboarding-v15.js
+++ b/bookmark-onboarding-v15.js
@@ -24,25 +24,26 @@
     document.head.appendChild(style);
   }
 
-  function updateGuidance(root) {
-    if (!root || typeof root.querySelectorAll !== 'function') return;
-
-    root.querySelectorAll('.bookmark-controls .inline-note').forEach(function (note) {
-      if ((note.textContent || '').trim() !== OLD_MESSAGE) return;
-      note.textContent = NEW_MESSAGE;
-      note.classList.add('skyfire-bookmark-folder-guidance');
-      note.setAttribute('role', 'note');
-    });
+  function applyMessage(note) {
+    if (!note || (note.textContent || '').trim() !== OLD_MESSAGE) return;
+    note.textContent = NEW_MESSAGE;
+    note.classList.add('skyfire-bookmark-folder-guidance');
+    note.setAttribute('role', 'note');
   }
 
-  function inspectNode(node) {
-    if (!(node instanceof Element)) return;
+  function updateGuidance(root) {
+    if (!root || !(root instanceof Element || root instanceof Document)) return;
 
-    if (node.matches('.bookmark-controls, .bookmark-controls .inline-note')) {
-      updateGuidance(node.matches('.bookmark-controls') ? node : node.parentElement);
+    if (root instanceof Element && root.matches('.bookmark-controls .inline-note')) {
+      applyMessage(root);
     }
 
-    updateGuidance(node);
+    if (root instanceof Element && root.matches('.bookmark-controls')) {
+      root.querySelectorAll('.inline-note').forEach(applyMessage);
+      return;
+    }
+
+    root.querySelectorAll('.bookmark-controls .inline-note').forEach(applyMessage);
   }
 
   addStyles();
@@ -50,7 +51,9 @@
 
   const observer = new MutationObserver(function (mutations) {
     mutations.forEach(function (mutation) {
-      mutation.addedNodes.forEach(inspectNode);
+      mutation.addedNodes.forEach(function (node) {
+        if (node instanceof Element) updateGuidance(node);
+      });
     });
   });
 

--- a/nested-tree.js
+++ b/nested-tree.js
@@ -2,7 +2,8 @@
 // The PPM reader is now rendered directly inside the MSHA Guidance section by ppm-guidance.js.
 // This file remains because older cached SkyFire shells still request it, and it also loads
 // v0.14 rule-specific guidance, reviewed Technical Guidance additions, stretch PPM content,
-// source-fidelity corrections, PPM audit corrections, and CFR full-screen reading polish.
+// source-fidelity corrections, PPM audit corrections, CFR full-screen reading polish,
+// and v0.15 bookmark onboarding guidance.
 (function () {
   window.SkyFireLegacyNestedTreeRetired = true;
 
@@ -22,4 +23,5 @@
   loadOnce('script[data-ppm-source-fidelity-v14="true"]', './ppm-source-fidelity-v14.js?v=v0.14-ppm-fidelity-1', 'ppmSourceFidelityV14');
   loadOnce('script[data-ppm-audit-v14="true"]', './ppm-audit-v14.js?v=v0.14-ppm-audit-1', 'ppmAuditV14');
   loadOnce('script[data-cfr-fullscreen-polish-v14="true"]', './cfr-fullscreen-polish-v14.js?v=v0.14-cfr-fullscreen-1', 'cfrFullscreenPolishV14');
+  loadOnce('script[data-bookmark-onboarding-v15="true"]', './bookmark-onboarding-v15.js?v=v0.15-bookmark-onboarding-1', 'bookmarkOnboardingV15');
 })();


### PR DESCRIPTION
Implements #29 for 30 CFR and 29 CFR readers.

- Replaces the vague zero-folder note with explicit guidance: create a bookmark folder in the Bookmarks panel first, then save the section to it.
- Keeps the guidance visually connected to bookmark controls.
- Applies to dynamically hydrated normal reader sections and Full Screen View.
- Leaves existing bookmark data/storage behavior unchanged.

QA requested after merge on phone and one larger-screen reader view.