### PR TITLE
Preserve CFR reader state when removing bookmarks (#30)

### DIFF
--- a/bookmark-remove-state-v15.js
+++ b/bookmark-remove-state-v15.js
@@ -1,0 +1,81 @@
+(function () {
+  let installTries = 0;
+
+  function getOpenFolderNames(container) {
+    if (!container) return [];
+
+    return Array.from(container.querySelectorAll('details.bookmark-folder[open]'))
+      .map(function (details) {
+        const summary = details.querySelector(':scope > summary.bookmark-folder-title');
+        return summary ? (summary.textContent || '').trim() : '';
+      })
+      .filter(Boolean);
+  }
+
+  function restoreOpenFolderNames(container, openFolderNames) {
+    if (!container || !openFolderNames.length) return;
+    const wanted = new Set(openFolderNames);
+
+    container.querySelectorAll('details.bookmark-folder').forEach(function (details) {
+      const summary = details.querySelector(':scope > summary.bookmark-folder-title');
+      const name = summary ? (summary.textContent || '').trim() : '';
+      if (wanted.has(name)) details.open = true;
+    });
+  }
+
+  function installPatch() {
+    if (
+      typeof window.removeBookmarkFromFolder !== 'function' ||
+      typeof window.renderBookmarkFolders !== 'function' ||
+      typeof window.sortBookmarkFolders !== 'function' ||
+      typeof window.saveBookmarkFolders !== 'function'
+    ) {
+      installTries += 1;
+      if (installTries < 80) window.setTimeout(installPatch, 50);
+      return;
+    }
+
+    if (window.removeBookmarkFromFolder.__skyfireV15PreserveReaderState === true) return;
+
+    const originalRemoveBookmarkFromFolder = window.removeBookmarkFromFolder;
+
+    const preserveReaderStateRemoveBookmark = function (libraryKey, folderId, sectionNumber) {
+      const state = libraryStates[libraryKey];
+      if (!state) {
+        return originalRemoveBookmarkFromFolder(libraryKey, folderId, sectionNumber);
+      }
+
+      const folder = state.bookmarkFolders.find(function (item) {
+        return item.id === folderId;
+      });
+      if (!folder) return;
+
+      const folderContainer = state.dom && state.dom.folderContainer;
+      const openFolderNames = getOpenFolderNames(folderContainer);
+      const scrollX = window.scrollX;
+      const scrollY = window.scrollY;
+
+      folder.items = folder.items.filter(function (item) {
+        return item.sectionNumber !== sectionNumber;
+      });
+
+      window.sortBookmarkFolders(libraryKey);
+      window.saveBookmarkFolders(state.config.bookmarksKey, state.bookmarkFolders);
+
+      // Refresh only the bookmark sidebar. Do not rerender the CFR/OSHA reader,
+      // which would collapse open hierarchy, disturb search results, and move scroll position.
+      window.renderBookmarkFolders(libraryKey);
+      restoreOpenFolderNames(folderContainer, openFolderNames);
+
+      window.requestAnimationFrame(function () {
+        window.scrollTo(scrollX, scrollY);
+      });
+    };
+
+    preserveReaderStateRemoveBookmark.__skyfireV15PreserveReaderState = true;
+    preserveReaderStateRemoveBookmark.__skyfireOriginal = originalRemoveBookmarkFromFolder;
+    window.removeBookmarkFromFolder = preserveReaderStateRemoveBookmark;
+  }
+
+  installPatch();
+})();

--- a/nested-tree.js
+++ b/nested-tree.js
@@ -3,7 +3,7 @@
 // This file remains because older cached SkyFire shells still request it, and it also loads
 // v0.14 rule-specific guidance, reviewed Technical Guidance additions, stretch PPM content,
 // source-fidelity corrections, PPM audit corrections, CFR full-screen reading polish,
-// and v0.15 bookmark onboarding guidance.
+// and v0.15 bookmark onboarding/state-preservation improvements.
 (function () {
   window.SkyFireLegacyNestedTreeRetired = true;
 
@@ -24,4 +24,5 @@
   loadOnce('script[data-ppm-audit-v14="true"]', './ppm-audit-v14.js?v=v0.14-ppm-audit-1', 'ppmAuditV14');
   loadOnce('script[data-cfr-fullscreen-polish-v14="true"]', './cfr-fullscreen-polish-v14.js?v=v0.14-cfr-fullscreen-1', 'cfrFullscreenPolishV14');
   loadOnce('script[data-bookmark-onboarding-v15="true"]', './bookmark-onboarding-v15.js?v=v0.15-bookmark-onboarding-1', 'bookmarkOnboardingV15');
+  loadOnce('script[data-bookmark-remove-state-v15="true"]', './bookmark-remove-state-v15.js?v=v0.15-bookmark-remove-state-1', 'bookmarkRemoveStateV15');
 })();


### PR DESCRIPTION
Implements #30 for 30 CFR and 29 CFR bookmark removal.

- Removes only the selected bookmark and refreshes only the bookmark sidebar.
- Avoids rerendering the CFR/OSHA reader, preserving open hierarchy, search results, and reading context.
- Preserves page scroll position during sidebar refresh.
- Restores any bookmark folders that were open before the removal.
- Leaves add-bookmark behavior and saved-bookmark navigation unchanged.

QA requested after merge using an existing bookmark while positioned inside an expanded CFR section/search result.