### PR TITLE
Release SkyFire v0.15 Beta metadata

### DIFF
--- a/feedback.js
+++ b/feedback.js
@@ -1,5 +1,5 @@
 const SKYFIRE_FEEDBACK_EMAIL = "skyfire.ehs.mining@gmail.com";
-const SKYFIRE_FEEDBACK_VERSION = "v0.14 Beta";
+const SKYFIRE_FEEDBACK_VERSION = "v0.15 Beta";
 
 function initializeFeedbackModule() {
   const form = document.getElementById("feedbackForm");

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         <div class="quick-info-card">
           <div class="quick-info-banner">
             <span class="quick-banner-title">Field Status Dashboard</span>
-            <span class="quick-banner-subtitle">SkyFire Safety Library v0.14 Beta — regulatory reference polish, complete PPM source fidelity, and expanded MSHA guidance.</span>
+            <span class="quick-banner-subtitle">SkyFire Safety Library v0.15 Beta — clearer bookmark onboarding and stronger CFR/OSHA reader-state preservation.</span>
           </div>
 
           <div class="quick-info-item">
@@ -57,7 +57,7 @@
 
           <div class="quick-info-item">
             <span class="quick-label">Last Updated</span>
-            <span class="quick-value" id="homeLastUpdated">September 2, 2026</span>
+            <span class="quick-value" id="homeLastUpdated">September 3, 2026</span>
           </div>
         </div>
       </section>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
-const SHELL_CACHE_NAME = "skyfire-quality-cache-v21";
+const SHELL_CACHE_NAME = "skyfire-quality-cache-v22";
 const DATA_CACHE_NAME = "skyfire-regulatory-data-v1";
-const CACHE_VERSION = "quality-v21";
+const CACHE_VERSION = "quality-v22";
 
 const SHELL_CACHE = [
   "./",
@@ -18,6 +18,9 @@ const SHELL_CACHE = [
   `./ppm-audit-v14.js?v=${CACHE_VERSION}`,
   `./cfr-fullscreen-polish-v14.js?v=${CACHE_VERSION}`,
   `./nested-tree.js?v=${CACHE_VERSION}`,
+  `./bookmark-onboarding-v15.js?v=${CACHE_VERSION}`,
+  `./bookmark-remove-state-v15.js?v=${CACHE_VERSION}`,
+  `./bookmark-folder-state-v15.js?v=${CACHE_VERSION}`,
   `./home-preview.js?v=${CACHE_VERSION}`,
   `./cfr-v13.js?v=${CACHE_VERSION}`,
   `./responsive-v13.js?v=${CACHE_VERSION}`,
@@ -113,6 +116,9 @@ self.addEventListener("fetch", event => {
     url.pathname.endsWith("/ppm-audit-v14.js") ||
     url.pathname.endsWith("/cfr-fullscreen-polish-v14.js") ||
     url.pathname.endsWith("/nested-tree.js") ||
+    url.pathname.endsWith("/bookmark-onboarding-v15.js") ||
+    url.pathname.endsWith("/bookmark-remove-state-v15.js") ||
+    url.pathname.endsWith("/bookmark-folder-state-v15.js") ||
     url.pathname.endsWith("/home-preview.js") ||
     url.pathname.endsWith("/cfr-v13.js") ||
     url.pathname.endsWith("/responsive-v13.js") ||


### PR DESCRIPTION
Closeout metadata for v0.15 Beta: dashboard/Feedback version update and explicit offline shell caching for the three v0.15 bookmark scripts.